### PR TITLE
fix: pyproject.toml setuptools packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ strict = true
 testpaths = ["tests"]
 markers = ["integration: requires live Holochain conductor + hc-http-gw"]
 addopts = "-m 'not integration'"
+
+[tool.setuptools.packages.find]
+include = ["bridge*"]
+exclude = ["docker*"]


### PR DESCRIPTION
This PR fix 
```
uv pip install -e ".[dev]"
Resolved 26 packages in 224ms
  × Failed to build `nondominium-erp-bridge @ file:///home/git/nondominium-erp-bridge`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_editable` failed (exit status: 1)

      [stderr]
      error: Multiple top-level packages discovered in a flat-layout: ['bridge', 'docker'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.

      hint: This usually indicates a problem with the package or the build environment.
      ```